### PR TITLE
Fix url for uhppoted-wiegand submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,7 +64,7 @@
 
 [submodule "uhppoted-wiegand"]
 	path = uhppoted-wiegand
-	url = https://github.com/uhppoted-wiegand.git
+	url = https://github.com/uhppoted/uhppoted-wiegand.git
 
 [submodule "uhppoted-python"]
 	path = uhppoted-python


### PR DESCRIPTION
The uhppoted-wiegand submodule has the incorrect url so when doing a git clone with the --recurse-submodules switch it fails causing the clone to not get all files. I have tested it in my fork and the fixed url allows the clone process to work successfully.